### PR TITLE
bounty: Fixed Platform Specific Image Order

### DIFF
--- a/hangman.py
+++ b/hangman.py
@@ -29,7 +29,7 @@ dash = "".join("_" for _ in range(animal_name_len))
 
 hangman_stages = [
     open(f"assets/{file}", "r", encoding="utf-8").read()
-    for file in os.listdir("assets/")
+    for file in sorted(os.listdir("assets/"))
     if file.endswith(".txt")
 ]
 


### PR DESCRIPTION
Fixes #6 

The fix is to wrap the call in `sorted()`, which sorts lexicographically and ensures the images appear in order. 